### PR TITLE
Remove set_attribute_was

### DIFF
--- a/lib/attr_encrypted/adapters/active_record.rb
+++ b/lib/attr_encrypted/adapters/active_record.rb
@@ -71,19 +71,6 @@ if defined?(ActiveRecord::Base)
             end
 
             define_method("#{attr}_with_dirtiness=") do |value|
-              ## Source: https://github.com/priyankatapar/attr_encrypted/commit/7e8702bd5418c927a39d8dd72c0adbea522d5663
-              # In ActiveRecord 5.2+, due to changes to the way virtual
-              # attributes are handled, @attributes[attr].value is nil which
-              # breaks attribute_was. Setting it here returns us to the expected
-              # behavior.
-              if Gem::Requirement.new('>= 5.2').satisfied_by?(RAILS_VERSION)
-                # This is needed support attribute_was before a record has
-                # been saved
-                set_attribute_was(attr, __send__(attr)) if value != __send__(attr)
-                # This is needed to support attribute_was after a record has
-                # been saved
-                @attributes.write_from_user(attr.to_s, value) if value != __send__(attr)
-              end
               attribute_will_change!(attr) if value != __send__(attr)
               __send__("#{attr}_without_dirtiness=", value)
             end


### PR DESCRIPTION
removed in rails 7

For a complicated history:
* The branch I was initially using to support Rails 7 was in a different fork of attr encrypted: https://github.com/attr-encrypted/attr_encrypted/compare/master...PagerTree:attr_encrypted:rails-7-0-support#
* This branch was 5 commits behind master and also 5 commits ahead
* I decided to use our existing attr_encrypted fork (done by Miguel a while back for ruby 3 support) and sync our fork with upstream master to have a cleaner fork we could control
* But then I found out a workaround for ActiveRecord 5.x was added in the 5 commits not picked up by the previous fork using set_attribute_was which is deprecated in Rails 7
* So essentially by trying to make a less messy fork, I picked up an unintended change from master that is not compatible with Rails 7 (ANOTHER incompatibility that attr_encrypted now has with Rails 7...)

